### PR TITLE
#264 質問詳細ページ下のウィジェットの開発

### DIFF
--- a/js/infinite-scroll-recent.js
+++ b/js/infinite-scroll-recent.js
@@ -1,0 +1,37 @@
+$(function(){
+  $('.ias-spinner').hide();
+  if($(".qa-qlist-recent .qa-q-list").length && $(".qa-page-links-list").length) {
+    if (material_lite) {
+      var ias = $(".mdl-layout__content").ias({
+        container: ".qa-qlist-recent .qa-q-list"
+        ,item: ".qa-q-list-item"
+        ,pagination: ".qa-page-links-list"
+        ,next: ".qa-page-next"
+        ,delay: 600
+      });
+    } else {
+        var ias = $.ias({
+            container: ".qa-qlist-recent .qa-q-list"
+            ,item: ".qa-q-list-item"
+            ,pagination: ".qa-page-links-list"
+            ,next: ".qa-page-next"
+            ,delay: 600
+        });
+        ias.extension(new IASSpinnerExtension());
+    }
+    ias.extension(new IASTriggerExtension({
+        text: "続きを読む",
+        textPrev: "前を読む",
+        offset: 100,
+    }));
+    ias.extension(new IASNoneLeftExtension({
+        html: '<div class="ias_noneleft">最後の記事です</div>', // optionally
+    }));
+    ias.on('load', function() {
+        $('.ias-spinner').show();
+    });
+    ias.on('noneLeft', function() {
+        $('.ias-spinner').hide();
+    });
+  }
+});

--- a/js/infinite-scroll-recent.js
+++ b/js/infinite-scroll-recent.js
@@ -5,7 +5,7 @@ $(function(){
       var ias = $(".mdl-layout__content").ias({
         container: ".qa-qlist-recent .qa-q-list"
         ,item: ".qa-q-list-item"
-        ,pagination: ".qa-page-links-list"
+        ,pagination: ".qa-page-links"
         ,next: ".qa-page-next"
         ,delay: 600
       });

--- a/qa-custom-related-qs-layer.php
+++ b/qa-custom-related-qs-layer.php
@@ -1,0 +1,42 @@
+<?php
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+    header('Location: ../../');
+    exit;
+}
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+    private $infscr = null;
+    private $pluginurl = '';
+    
+    function qa_html_theme_layer($template, $content, $rooturl, $request)
+    {
+        qa_html_theme_base::qa_html_theme_base($template, $content, $rooturl, $request);
+        if(infinite_scroll_available()) {
+            require_once QA_PLUGIN_DIR . 'q2a-infinite-scroll/qa-infinite-scroll.php';
+            $this->infscr = new qa_infinite_scroll();
+        }
+        $this->pluginurl = qa_opt('site_url').'qa-plugin/q2a-custom-related-questions/';
+    }
+
+    function head_script()
+    {
+        qa_html_theme_base::head_script();
+        if ($this->template === 'question' && isset($this->infscr)) {
+            if (strpos(qa_opt('site_theme'), 'q2a-material-lite') !== false) {
+                $this->output('<script>var material_lite = true;</script>');
+            } else {
+                $this->output('<script>var material_lite = false;</script>');
+            }
+            $this->output('<SCRIPT TYPE="text/javascript" SRC="'.$this->infscr->pluginjsurl.'jquery-ias.min.js"></SCRIPT>');
+            $this->output('<SCRIPT TYPE="text/javascript" SRC="'.$this->pluginurl.'js/infinite-scroll-recent.js"></SCRIPT>');
+        }
+    }
+    function head_css()
+    {
+        qa_html_theme_base::head_css();
+        if ($this->template === 'question' && isset($this->infscr)) {
+            $this->output('<LINK REL="stylesheet" TYPE="text/css" HREF="'.$this->infscr->plugincssurl.'jquery.ias.css"/>');
+        }
+    }
+}

--- a/qa-custom-related-qs-widget.php
+++ b/qa-custom-related-qs-widget.php
@@ -25,15 +25,18 @@ class qa_custom_related_qs
         $cookieid = qa_cookie_get();
         
         // 関連する質問
-        $this->output_related_questions($region, $place, $themeobject, $userid, $questionid, $cookieid);
+        $questions = $this->get_related_questions($userid, $questionid);
+        $titlehtml = qa_lang_html(count($questions) ? 'main/related_qs_title' : 'main/no_related_qs_title');
+        $this->output_related_questions($region, $place, $themeobject, $userid, $cookieid, $titlehtml,  $questions);
         
         // おなじ季節の質問
-        $this->output_questions_widget($region, $place, $themeobject, $userid, $cookieid);
+        $questions = $this->get_seasonal_questions();
+        $titlehtml = '同じ季節の質問';;
+        $this->output_questions_widget($region, $place, $themeobject, $userid, $cookieid, $titlehtml,  $questions);
     }
     
-    function output_related_questions($region, $place, $themeobject, $userid, $questionid, $cookieid)
+    function get_related_questions($userid, $questionid)
     {
-        
         $questions = qa_db_single_select(qa_db_related_qs_selectspec($userid, $questionid, 15));
 
         $minscore = qa_match_to_min_score(qa_opt('match_related_qs'));
@@ -44,8 +47,17 @@ class qa_custom_related_qs
                 unset($questions[$key]);
             }
         }
-        $questions = array_slice($questions, 0, 5);
-        $titlehtml = qa_lang_html(count($questions) ? 'main/related_qs_title' : 'main/no_related_qs_title');
+        return array_slice($questions, 0, 5);
+    }
+    
+    
+    function get_seasonal_questions()
+    {
+        return array();
+    }
+    
+    function output_questions_widget($region, $place, $themeobject, $userid, $cookieid, $titlehtml, $questionid)
+    {
         if ($region == 'side') {
             $themeobject->output(
                 '<div class="qa-related-qs">',
@@ -95,37 +107,5 @@ class qa_custom_related_qs
 
             $themeobject->q_list_and_form($q_list);
         }
-    }
-    
-    function output_questions_widget($region, $place, $themeobject, $userid, $cookieid)
-    {
-        $title = '同じ季節の質問';
-        $questions = $this->getSeasonalQuestions();
-        $titlehtml = $title;
-        $themeobject->output( '<h2>', $titlehtml, '</h2>');
-        $q_list=array(
-                'form' => array(
-                    'tags' => 'method="post" action="'.qa_self_html().'"',
-
-                    'hidden' => array(
-                        'code' => qa_get_form_security_code('vote'),
-                    ),
-                ),
-
-                'qs' => array(),
-            );
-        $defaults=qa_post_html_defaults('Q');
-        $usershtml=qa_userids_handles_html($questions);
-
-        foreach ($questions as $question) {
-            $q_list['qs'][]=qa_post_html_fields($question, $userid, $cookieid, $usershtml, null, qa_post_html_options($question, $defaults));
-        }    
-
-        $themeobject->q_list_and_form($q_list);
-    }
-    
-    function getSeasonalQuestions()
-    {
-        return array();
     }
 }

--- a/qa-custom-related-qs-widget.php
+++ b/qa-custom-related-qs-widget.php
@@ -1,0 +1,95 @@
+<?php
+
+class qa_custom_related_qs
+{
+    public function allow_template($template)
+    {
+        return $template == 'question';
+    }
+
+    public function allow_region($region)
+    {
+        return in_array($region, array('side', 'main', 'full'));
+    }
+
+    public function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
+    {
+        require_once QA_INCLUDE_DIR.'db/selects.php';
+
+        if (!isset($qa_content['q_view']['raw']['type']) || $qa_content['q_view']['raw']['type'] != 'Q') // question might not be visible, etc...
+            return;
+
+        $questionid = $qa_content['q_view']['raw']['postid'];
+
+        $userid = qa_get_logged_in_userid();
+        $cookieid = qa_cookie_get();
+        
+        $this->output_related_questions($userid, $questionid, $cookieid, $region, $place, $themeobject);
+    }
+    
+    function output_related_questions($userid, $questionid, $cookieid, $region, $place, $themeobject)
+    {
+        
+        $questions = qa_db_single_select(qa_db_related_qs_selectspec($userid, $questionid, 15));
+
+        $minscore = qa_match_to_min_score(qa_opt('match_related_qs'));
+        $minacount = 2;
+        
+        foreach ($questions as $key => $question) {
+            if ($question['score'] < $minscore || $question['acount'] < $minacount) {
+                unset($questions[$key]);
+            }
+        }
+        $questions = array_slice($questions, 0, 5);
+        $titlehtml = qa_lang_html(count($questions) ? 'main/related_qs_title' : 'main/no_related_qs_title');
+        if ($region == 'side') {
+            $themeobject->output(
+                '<div class="qa-related-qs">',
+                '<h2 style="margin-top:0; padding-top:0;">',
+                $titlehtml,
+                '</h2>'
+            );
+
+            $themeobject->output('<ul class="qa-related-q-list">');
+
+            foreach ($questions as $question) {
+                $themeobject->output(
+                        '<li class="qa-related-q-item">' .
+                        '<a href="' . qa_q_path_html($question['postid'], $question['title']) . '">' .
+                        qa_html($question['title']) .
+                        '</a>' .
+                        '</li>'
+                );
+            }
+
+            $themeobject->output(
+                '</ul>',
+                '</div>'
+            );
+        } else {
+            $themeobject->output(
+                '<h2>',
+                $titlehtml,
+                '</h2>'
+            );
+
+            $q_list = array(
+                'form' => array(
+                    'tags' => 'method="post" action="' . qa_self_html() . '"',
+                    'hidden' => array(
+                        'code' => qa_get_form_security_code('vote'),
+                    ),
+                ),
+                'qs' => array(),
+            );
+
+            $defaults = qa_post_html_defaults('Q');
+            $usershtml = qa_userids_handles_html($questions);
+
+            foreach ($questions as $question)
+                $q_list['qs'][] = qa_post_html_fields($question, $userid, $cookieid, $usershtml, null, qa_post_html_options($question, $defaults));
+
+            $themeobject->q_list_and_form($q_list);
+        }
+    }
+}

--- a/qa-custom-related-qs-widget.php
+++ b/qa-custom-related-qs-widget.php
@@ -27,7 +27,7 @@ class qa_custom_related_qs
         // 関連する質問
         $questions = $this->get_related_questions($userid, $questionid);
         $titlehtml = qa_lang_html(count($questions) ? 'main/related_qs_title' : 'main/no_related_qs_title');
-        $this->output_related_questions($region, $place, $themeobject, $userid, $cookieid, $titlehtml,  $questions);
+        $this->output_questions_widget($region, $place, $themeobject, $userid, $cookieid, $titlehtml,  $questions);
         
         // おなじ季節の質問
         $questions = $this->get_seasonal_questions();
@@ -53,10 +53,23 @@ class qa_custom_related_qs
     
     function get_seasonal_questions()
     {
-        return array();
+        $month = date("m");
+        $day= date("j");
+        $day = floor($day/10);
+        if($day == 3) {
+            $day  = 2;
+        }
+        $date = '%-' . $month . '-' . $day . '%';
+
+        $userid = '1';
+        $selectspec=qa_db_posts_basic_selectspec($userid);
+        $selectspec['source'] .=" WHERE type='Q'";
+        $selectspec['source'] .= " AND ^posts.created like '" . $date . "' ORDER BY RAND() LIMIT 5";
+        $questions=qa_db_single_select($selectspec);
+        return $questions;
     }
     
-    function output_questions_widget($region, $place, $themeobject, $userid, $cookieid, $titlehtml, $questionid)
+    function output_questions_widget($region, $place, $themeobject, $userid, $cookieid, $titlehtml, $questions)
     {
         if ($region == 'side') {
             $themeobject->output(

--- a/qa-custom-related-qs-widget.php
+++ b/qa-custom-related-qs-widget.php
@@ -24,10 +24,14 @@ class qa_custom_related_qs
         $userid = qa_get_logged_in_userid();
         $cookieid = qa_cookie_get();
         
-        $this->output_related_questions($userid, $questionid, $cookieid, $region, $place, $themeobject);
+        // 関連する質問
+        $this->output_related_questions($region, $place, $themeobject, $userid, $questionid, $cookieid);
+        
+        // おなじ季節の質問
+        $this->output_questions_widget($region, $place, $themeobject, $userid, $cookieid);
     }
     
-    function output_related_questions($userid, $questionid, $cookieid, $region, $place, $themeobject)
+    function output_related_questions($region, $place, $themeobject, $userid, $questionid, $cookieid)
     {
         
         $questions = qa_db_single_select(qa_db_related_qs_selectspec($userid, $questionid, 15));
@@ -91,5 +95,37 @@ class qa_custom_related_qs
 
             $themeobject->q_list_and_form($q_list);
         }
+    }
+    
+    function output_questions_widget($region, $place, $themeobject, $userid, $cookieid)
+    {
+        $title = '同じ季節の質問';
+        $questions = $this->getSeasonalQuestions();
+        $titlehtml = $title;
+        $themeobject->output( '<h2>', $titlehtml, '</h2>');
+        $q_list=array(
+                'form' => array(
+                    'tags' => 'method="post" action="'.qa_self_html().'"',
+
+                    'hidden' => array(
+                        'code' => qa_get_form_security_code('vote'),
+                    ),
+                ),
+
+                'qs' => array(),
+            );
+        $defaults=qa_post_html_defaults('Q');
+        $usershtml=qa_userids_handles_html($questions);
+
+        foreach ($questions as $question) {
+            $q_list['qs'][]=qa_post_html_fields($question, $userid, $cookieid, $usershtml, null, qa_post_html_options($question, $defaults));
+        }    
+
+        $themeobject->q_list_and_form($q_list);
+    }
+    
+    function getSeasonalQuestions()
+    {
+        return array();
     }
 }

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+    Plugin Name: Custom Related Questions
+    Plugin URI:
+    Plugin Description: Customize related questions widget
+    Plugin Version: 1.0
+    Plugin Date: 2016-10-18
+    Plugin Author: 38qa.net
+    Plugin Author URI: http://38qa.net/
+    Plugin License: GPLv2
+    Plugin Minimum Question2Answer Version: 1.7
+    Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+    header('Location: ../../');
+    exit;
+}

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -17,3 +17,5 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
     header('Location: ../../');
     exit;
 }
+
+qa_register_plugin_module('widget','qa-custom-related-qs-widget.php','qa_custom_related_qs','Custom Related Questions');

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -19,3 +19,14 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 }
 
 qa_register_plugin_module('widget','qa-custom-related-qs-widget.php','qa_custom_related_qs','Custom Related Questions');
+qa_register_plugin_layer('qa-custom-related-qs-layer.php', 'Custom Related Questions Layer');
+
+function infinite_scroll_available()
+{
+    global $qa_layers;
+    if (array_key_exists('Infinite Scroll Layer', $qa_layers)) {
+        return true;
+    } else {
+        return false;
+    }
+}


### PR DESCRIPTION
### 1. 関連する質問は、回答が2つ以上ついているもののみ表示する
* もとの Related Questions ウィジェットを少し改造して、acount < 2 のものは除外する

* はじめに関連する質問を **15件** 取ってきてそのなかから acount >= 2 のものを最大5件表示

* 15にとくに意味はないが多すぎると関連性が薄れる、少なすぎると acount >= 2 の質問がない場合があるので。