### PR TITLE
1719 質問詳細ページの下部のイベントのお知らせも飼育日誌と同様のデザインに

### DIFF
--- a/css/related-qs.css
+++ b/css/related-qs.css
@@ -1,0 +1,75 @@
+/* イベントのお知らせ部分 */
+#events-list.two-columns h2 {
+  margin-top: 0;
+  padding-left: 0;
+}
+@media (min-width: 768px) {
+  #events-list.two-columns {
+    padding: 0 8px;
+    margin-top: 10px;
+  }
+  #events-list.two-columns h2 {
+    padding: unset;
+  }
+  #events-list.two-columns .qa-q-list {
+    display: -webkit-flex;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+  }
+  #events-list.two-columns .qa-q-list section {
+    width: calc(50% - 8px);
+    margin-bottom: 16px;
+  }
+  #events-list.two-columns .qa-q-list section:nth-child(odd) {
+    margin-right: 16px;
+  }
+  #events-list.two-columns .qa-q-list section .qa-q-list-item {
+    height: 100%;
+  }
+  #events-list.two-columns .qa-q-list section .qa-q-list-item .mdl-card {
+    height: 100%;
+    margin: 0;
+    width: 100%;
+  }
+}
+#events-list .qa-view-count {
+  position: absolute;
+  width: 40px;
+  left: 0;
+  top: 0;
+  line-height: 1.2;
+  color: #fff;
+  background: transparent;
+}
+#events-list .qa-view-count:after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 6rem 6rem 0 0;
+  border-color: rgba(255,110,64,0.7) transparent transparent transparent;
+}
+#events-list .qa-view-count.count-zero:after {
+  border-color: rgba(0,0,0,0.2) transparent transparent transparent;
+}
+#events-list .qa-view-count .qa-view-count-pad {
+  position: absolute;
+  z-index: 10;
+  top: 6px;
+  left: 8px;
+}
+#events-list .qa-view-count .qa-view-count-data {
+  position: absolute;
+  font-size: 1.5rem;
+  z-index: 10;
+  top: 24px;
+  width: 25px;
+  display: block;
+  text-align: center;
+}

--- a/qa-custom-related-qs-layer.php
+++ b/qa-custom-related-qs-layer.php
@@ -14,6 +14,16 @@ class qa_html_theme_layer extends qa_html_theme_base
         $this->pluginurl = qa_opt('site_url').'qa-plugin/q2a-custom-related-questions/';
     }
 
+    function head_css()
+    {
+        qa_html_theme_base::head_css();
+        if ($this->template === 'question') {
+            $custom_css = $this->pluginurl.'css/related-qs.css';
+            $this->output( '<link rel="stylesheet" type="text/css" href="' . $custom_css . '"/>' );
+
+        }
+    }
+
     function body_footer()
     {
         qa_html_theme_base::body_footer();

--- a/related-qs-utils.php
+++ b/related-qs-utils.php
@@ -323,6 +323,7 @@ class related_qs_utils {
 
         $html .= self::get_events_html($userid, $themeobject);
 
+        $themeobject->template = 'ajax-rlated-qs';
         $questions2 = self::get_related_questions_hall($userid, $questionid);
         if (count($questions2) > 0) {
             $titlehtml = qa_lang('custom_related_qs/fame_title');

--- a/related-qs-utils.php
+++ b/related-qs-utils.php
@@ -291,10 +291,8 @@ class related_qs_utils {
 
         // 他サイト（獣害Q&A）の投稿
         if (qa_opt('material_lite_option_show_others')) {
-            error_log('DEBUG get_related_qa_html_hall');
             $other_q_list_html = self::get_other_q_list_html($themeobject);
             if (!empty($other_q_list_html)) {
-                error_log('DEBUG othe_q_list show');
                 $html .= $other_q_list_html;
             }
         }
@@ -323,7 +321,7 @@ class related_qs_utils {
             $html .= ob_get_clean();
         }
 
-        $html .= self::get_events_html();
+        $html .= self::get_events_html($userid, $themeobject);
 
         $questions2 = self::get_related_questions_hall($userid, $questionid);
         if (count($questions2) > 0) {
@@ -364,9 +362,12 @@ class related_qs_utils {
     /*
      * イベントのお知らせのHTML
      */
-    public static function get_events_html()
+    public static function get_events_html($userid, $themeobj)
     {
-        return qa_theme_utils::get_side_events_html();
+        // return qa_theme_utils::get_side_events_html();
+        $html = qas_blog_get_event_notices_html($userid, 0, self::CACHE_EXPIRES, $themeobj);
+        $html = '<div id="events-list" class="two-columns">'.$html.'</div>';
+        return $html;
     }
 
     private static function get_other_q_list_html($themeobject)


### PR DESCRIPTION
- blog プラグインの関数を利用してイベントのお知らせを取得
- お知らせ部分のCSSを調整